### PR TITLE
some keybindings should handle `text-field%` this possibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### To Release
 
-- [editor:fix] `space` will work under "show log" now
+- [editor:fix] `space` will work for `text-field%` now
+- [editor:fix] `alt+backspace` will work for `text-field%` now
 
 ### v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### To Release
 
+- [editor:fix] `space` will work under "show log" now
+
 ### v1.3.0
 
 - [shortcut:fix] `o+backspace` and `space` on improper editor

--- a/shortcut.rkt
+++ b/shortcut.rkt
@@ -161,4 +161,4 @@
          (send editor
                insert
                (hash-ref latex-complete (string-trim to-complete "\\" #:right? #f) to-complete)))))
-   (send editor insert " ")))
+   (send (if (is-a? editor text-field%) (send editor get-editor) editor) insert " ")))

--- a/shortcut.rkt
+++ b/shortcut.rkt
@@ -82,13 +82,13 @@
 
 ;;; delete previous sexp
 (opt/alt+ "backspace"
-          (λ (editor event)
-            (when (object-method-arity-includes? editor 'get-backward-sexp 1)
-              (let* ([cur-pos (send editor get-start-position)]
-                     [pre-sexp-pos (send editor get-backward-sexp cur-pos)])
-                ; ensure pre-sexp existed
-                (when pre-sexp-pos
-                  (send editor delete pre-sexp-pos cur-pos))))))
+          (λ (ed event)
+            (define editor (if (is-a? ed text-field%) (send ed get-editor) ed))
+            (let* ([cur-pos (send editor get-start-position)]
+                   [pre-sexp-pos (send editor get-backward-sexp cur-pos)])
+              ; ensure pre-sexp existed
+              (when pre-sexp-pos
+                (send editor delete pre-sexp-pos cur-pos)))))
 
 ;;; comment/uncomment selected text, if no selected text, target is current line
 (cmd/ctrl+
@@ -147,18 +147,17 @@
 
 (keybinding
  "space"
- (λ (editor event)
-   (when (and (object-method-arity-includes? editor 'get-backward-sexp 1)
-              (object-method-arity-includes? editor 'insert 1))
-     (define end (send editor get-start-position))
-     (define start (send editor get-backward-sexp end))
-     (when start
-       (define to-complete (send editor get-text start end))
-       (when (string-prefix? to-complete "\\")
-         ;;; select previous sexp
-         (send editor set-position start end)
-         ;;; replace it with new text
-         (send editor
-               insert
-               (hash-ref latex-complete (string-trim to-complete "\\" #:right? #f) to-complete)))))
-   (send (if (is-a? editor text-field%) (send editor get-editor) editor) insert " ")))
+ (λ (ed event)
+   (define editor (if (is-a? ed text-field%) (send ed get-editor) ed))
+   (define end (send editor get-start-position))
+   (define start (send editor get-backward-sexp end))
+   (when start
+     (define to-complete (send editor get-text start end))
+     (when (string-prefix? to-complete "\\")
+       ;;; select previous sexp
+       (send editor set-position start end)
+       ;;; replace it with new text
+       (send editor
+             insert
+             (hash-ref latex-complete (string-trim to-complete "\\" #:right? #f) to-complete))))
+   (send editor insert " ")))


### PR DESCRIPTION
- [editor:fix] `space` will work for `text-field%` now
- [editor:fix] `alt+backspace` will work for `text-field%` now

resolve #191 