### PR TITLE
[porject] add/remove file only update the affected node

### DIFF
--- a/path/util.rkt
+++ b/path/util.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (provide basename
-         config-dir)
+         config-dir
+         parent-path)
 
 (define config-dir (build-path (find-system-path 'home-dir) ".sauron"))
 ; create config directory if not exised
@@ -10,6 +11,10 @@
 (define (basename path)
   (define-values [base file dir?] (split-path path))
   (path->string file))
+
+(define (parent-path path)
+  (define-values [base file dir?] (split-path path))
+  base)
 
 (module+ test
   (require rackunit

--- a/project/panel.rkt
+++ b/project/panel.rkt
@@ -16,9 +16,15 @@ modifier author: Lîm Tsú-thuàn(GitHub: @dannypsnl)
          sauron/path/renamer)
 
 (define set-text-mixin
-  (mixin (hierarchical-list-item<%>) ((interface () set-text))
+  (mixin (hierarchical-list-item<%>) ((interface () set-text get-text))
     (inherit get-editor)
     (super-new)
+
+    ; get-text: return the label of item
+    (define/public (get-text)
+      (define t (get-editor)) ; a text% object
+      (send t get-text))
+    
     ; set-text: this sets the label of the item
     (define/public (set-text str)
       (define t (get-editor)) ; a text% object
@@ -113,6 +119,7 @@ modifier author: Lîm Tsú-thuàn(GitHub: @dannypsnl)
                      (send* item
                        [set-text (basename path)]
                        [user-data (selected (path-only path) path (parent-path path))])
+                     (send this sort (lambda (lhs rhs) (string<? (send lhs get-text) (send rhs get-text))))
                      (store-item-by-path path item)
                      (create path))]
                   [(list 'robust 'remove path)


### PR DESCRIPTION
add/remove file event in, only insert or delete the item. but refresh-tree-view is still reconstruct the whole file structure.

should somehow fix :) Issue #208

didn't test on other OS !