### PR TITLE
refactor, stop provide record out

### DIFF
--- a/collect/api.rkt
+++ b/collect/api.rkt
@@ -6,9 +6,7 @@
          get-def
          update
          create)
-(require data/interval-map
-         sauron/collect/record
-         sauron/collect/record-maintainer)
+(require sauron/collect/record-maintainer)
 
 (define (start-tracking directory ignore?)
   ; NOTE: `fold-files` reduces about 100MB compare with `find-files`
@@ -33,26 +31,31 @@
   (thread-send (get-record-maintainer path #:wait? #t)
                (list 'update)))
 
+; require-location? : path path -> list
 (define (require-location? path require)
-  (match-define (struct* record ([requires requires]))
-    (get-record path))
-  (hash-ref requires require #f))
+  (thread-send (get-record-maintainer path #:wait? #t)
+               (list 'require-location?
+                     (current-thread)
+                     require))
+  (thread-receive))
+; get-doc : path pos:exact-integer? -> string
 (define (get-doc path pos)
-  (match-define (struct* record ([doc doc]))
-    (get-record path))
-  (interval-map-ref doc pos #f))
+  (thread-send (get-record-maintainer path #:wait? #t)
+               (list 'get-doc
+                     (current-thread)
+                     pos))
+  (thread-receive))
+; jump-to-def : path pos:exact-integer? -> binding
 (define (jump-to-def path from-pos)
-  (match-define (struct* record ([bindings bindings]))
-    (get-record path))
-  (interval-map-ref bindings from-pos #f))
+  (thread-send (get-record-maintainer path #:wait? #t)
+               (list 'jump-to-def
+                     (current-thread)
+                     from-pos))
+  (thread-receive))
 ; get-def : path id -> binding
 (define (get-def path id)
-  (match-define (struct* record ([defs defs]))
-    (get-record path))
-  (hash-ref defs id #f))
-
-;;; try get record from maintainer map via path
-(define (get-record path)
   (thread-send (get-record-maintainer path #:wait? #t)
-               (list 'get-record (current-thread)))
+               (list 'get-def
+                     (current-thread)
+                     id))
   (thread-receive))

--- a/collect/record-maintainer.rkt
+++ b/collect/record-maintainer.rkt
@@ -6,6 +6,7 @@
          racket/future
          racket/function
          racket/match
+         data/interval-map
          sauron/collect/record
          sauron/collect/collector
          sauron/log)
@@ -77,7 +78,21 @@
          (match-define (struct* record ([created-time created-time])) cached-record)
          (when (< created-time (file-or-directory-modify-seconds file-path))
            (set! cached-record (collect-from file-path)))]
-        ;; to invoke this, you must provide your thread-id as from
-        [(list 'get-record from)
-         (thread-send from cached-record)])
+
+        [(list 'require-location? from require)
+         (define requires (record-requires cached-record))
+         (thread-send from (hash-ref requires require #f))]
+
+        [(list 'get-doc from pos)
+         (define doc (record-doc cached-record))
+         (thread-send from (interval-map-ref doc pos #f))]
+
+        [(list 'jump-to-def from from-pos)
+         (define bindings (record-bindings cached-record))
+         (thread-send from (interval-map-ref bindings from-pos #f))]
+
+        [(list 'get-def from id)
+         (define defs (record-defs cached-record))
+         (thread-send from (hash-ref defs id #f))]
+        )
       (loop)))))


### PR DESCRIPTION
The problem will be, if I only forward a thread-message to a place, that will not improve the respond ability, because others `collect-from` will block the place worker.

The two-level workers must be done, but `record` cannot be pass via place-channel.