### PR TITLE
Update info.rkt dependencies from 'from-template' to 'new'

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -12,7 +12,7 @@
            "try-catch-finally-lib"
            "curly-fn-lib"
            ; bundle
-           "new"
+           "raco-new"
            "drcomplete"))
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "gui-doc"))
 (define scribblings '(("scribblings/sauron.scrbl" (multi-page) ("DrRacket Plugins"))))

--- a/info.rkt
+++ b/info.rkt
@@ -12,7 +12,7 @@
            "try-catch-finally-lib"
            "curly-fn-lib"
            ; bundle
-           "from-template"
+           "new"
            "drcomplete"))
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "gui-doc"))
 (define scribblings '(("scribblings/sauron.scrbl" (multi-page) ("DrRacket Plugins"))))


### PR DESCRIPTION
change dependency to new version of Racket templates 

https://pkgd.racket-lang.org/pkgn/package/from-template to https://pkgd.racket-lang.org/pkgn/package/new